### PR TITLE
fix(modal): forward ModalRenderProps to children

### DIFF
--- a/components/ui/modal.tsx
+++ b/components/ui/modal.tsx
@@ -124,16 +124,14 @@ const ModalContent = ({
         )}
         {...props}
       >
-        <Dialog role={role}>
-          {({ close }) => (
-            <>
-              {children}
-              {closeButton && (
-                <Dialog.CloseIndicator close={close} isDismissable={_isDismissable} />
-              )}
-            </>
-          )}
-        </Dialog>
+        {(values) => (
+					<Dialog role={role}>
+						{typeof children === 'function' ? children(values) : children}
+						{closeButton && (
+							<Dialog.CloseIndicator close={values.state.close} isDismissable={_isDismissable} />
+						)}
+					</Dialog>
+				)}
       </ModalPrimitive>
     </ModalOverlayPrimitive>
   )

--- a/components/ui/modal.tsx
+++ b/components/ui/modal.tsx
@@ -125,13 +125,13 @@ const ModalContent = ({
         {...props}
       >
         {(values) => (
-					<Dialog role={role}>
-						{typeof children === 'function' ? children(values) : children}
-						{closeButton && (
-							<Dialog.CloseIndicator close={values.state.close} isDismissable={_isDismissable} />
-						)}
-					</Dialog>
-				)}
+          <Dialog role={role}>
+            {typeof children === "function" ? children(values) : children}
+            {closeButton && (
+              <Dialog.CloseIndicator close={values.state.close} isDismissable={_isDismissable} />
+            )}
+          </Dialog>
+        )}
       </ModalPrimitive>
     </ModalOverlayPrimitive>
   )


### PR DESCRIPTION
**Hi there 👋**

I've made a tiny fix to the Modal component: **Modal render props are now forwarded correctly to functional children**.

I'll take this opportunity to thank you for your hard work on this project 🫶🏻 