### PR TITLE
Hide MS Edge reveal button

### DIFF
--- a/resources/content/docs/getting-started/installation.mdx
+++ b/resources/content/docs/getting-started/installation.mdx
@@ -248,6 +248,9 @@ Include this for the default set of utilities:
 
   body {
     @apply bg-bg text-fg;
+    ::-ms-reveal {
+      display: none;
+    }
   }
 }
 `} />


### PR DESCRIPTION
MS Edge adds its own reveal button to an input field of type "password". It took a while to find out, why I could see two eye icons next to each other ;-)

-> https://learn.microsoft.com/en-us/microsoft-edge/web-platform/password-reveal

The added styles hides the Edge eye.

![image](https://github.com/user-attachments/assets/751d689a-5e97-47a2-bb38-6544fabab8f3)
