### PR TITLE
Change hsl to oklch in manual installation

### DIFF
--- a/resources/content/docs/getting-started/installation.mdx
+++ b/resources/content/docs/getting-started/installation.mdx
@@ -260,7 +260,7 @@ Then, add this section for react-aria-components:
 
 ```css
 .react-aria-DropIndicator[data-drop-target] {
-  outline: 1px solid hsl(var(--primary));
+  outline: 1px solid oklch(var(--primary));
 }
 ```
 
@@ -282,55 +282,55 @@ export default withTV({
   theme: {
     extend: {
       colors: {
-        light: "hsl(var(--light))",
-        dark: "hsl(var(--dark))",
-        border: "hsl(var(--border))",
-        input: "hsl(var(--input))",
-        ring: "hsl(var(--ring))",
-        toggle: "hsl(var(--toggle))",
-        bg: "hsl(var(--bg))",
-        fg: "hsl(var(--fg))",
+        light: "oklch(var(--light))",
+        dark: "oklch(var(--dark))",
+        border: "oklch(var(--border))",
+        input: "oklch(var(--input))",
+        ring: "oklch(var(--ring))",
+        toggle: "oklch(var(--toggle))",
+        bg: "oklch(var(--bg))",
+        fg: "oklch(var(--fg))",
         primary: {
-          DEFAULT: "hsl(var(--primary))",
-          fg: "hsl(var(--primary-fg))",
+          DEFAULT: "oklch(var(--primary))",
+          fg: "oklch(var(--primary-fg))",
         },
         secondary: {
-          DEFAULT: "hsl(var(--secondary))",
-          fg: "hsl(var(--secondary-fg))"
+          DEFAULT: "oklch(var(--secondary))",
+          fg: "oklch(var(--secondary-fg))"
         },
         tertiary: {
-          DEFAULT: "hsl(var(--tertiary))",
-          fg: "hsl(var(--tertiary-fg))"
+          DEFAULT: "oklch(var(--tertiary))",
+          fg: "oklch(var(--tertiary-fg))"
         },
         accent: {
-          DEFAULT: "hsl(var(--accent))",
-          fg: "hsl(var(--accent-fg))",
-          subtle: "hsl(var(--accent-subtle))",
-          "subtle-fg": "hsl(var(--accent-subtle-fg))"
+          DEFAULT: "oklch(var(--accent))",
+          fg: "oklch(var(--accent-fg))",
+          subtle: "oklch(var(--accent-subtle))",
+          "subtle-fg": "oklch(var(--accent-subtle-fg))"
         },
         success: {
-          DEFAULT: "hsl(var(--success))",
-          fg: "hsl(var(--success-fg))"
+          DEFAULT: "oklch(var(--success))",
+          fg: "oklch(var(--success-fg))"
         },
         info: {
-          DEFAULT: "hsl(var(--info))",
-          fg: "hsl(var(--info-fg))"
+          DEFAULT: "oklch(var(--info))",
+          fg: "oklch(var(--info-fg))"
         },
         danger: {
-          DEFAULT: "hsl(var(--danger))",
-          fg: "hsl(var(--danger-fg))"
+          DEFAULT: "oklch(var(--danger))",
+          fg: "oklch(var(--danger-fg))"
         },
         warning: {
-          DEFAULT: "hsl(var(--warning))",
-          fg: "hsl(var(--warning-fg))"
+          DEFAULT: "oklch(var(--warning))",
+          fg: "oklch(var(--warning-fg))"
         },
         muted: {
-          DEFAULT: "hsl(var(--muted))",
-          fg: "hsl(var(--muted-fg))"
+          DEFAULT: "oklch(var(--muted))",
+          fg: "oklch(var(--muted-fg))"
         },
         overlay: {
-          DEFAULT: "hsl(var(--overlay))",
-          fg: "hsl(var(--overlay-fg))"
+          DEFAULT: "oklch(var(--overlay))",
+          fg: "oklch(var(--overlay-fg))"
         }
       },
       borderRadius: {


### PR DESCRIPTION
In the manual installation the vars use oklch but tailwind config uses hsl.