### PR TITLE
fix(ui): Update import statements in ui components

### DIFF
--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 
-import { cn } from '@/utils/classes'
 import { tv } from 'tailwind-variants'
 
 import { Heading } from './heading'
+import { cn } from './primitive'
 
 const card = tv({
   slots: {

--- a/components/ui/chart.tsx
+++ b/components/ui/chart.tsx
@@ -2,8 +2,9 @@
 
 import * as React from 'react'
 
-import { cn } from '@/utils/classes'
 import { Legend, type LegendProps, ResponsiveContainer as Container, Tooltip } from 'recharts'
+
+import { cn } from './primitive'
 
 interface Theme {
   readonly light: string

--- a/components/ui/search-field.tsx
+++ b/components/ui/search-field.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { Loader } from '@/components/ui/loader'
 import { IconSearch, IconX } from 'justd-icons'
 import {
   SearchField as SearchFieldPrimitive,
@@ -10,6 +9,7 @@ import {
 import { tv } from 'tailwind-variants'
 
 import { Button } from './button'
+import { Loader } from './loader'
 import { Description, FieldError, FieldGroup, Input, Label } from './field'
 import { ctr } from './primitive'
 

--- a/components/ui/text-field.tsx
+++ b/components/ui/text-field.tsx
@@ -2,7 +2,6 @@
 
 import * as React from 'react'
 
-import { Loader } from '@/components/ui/loader'
 import type { TextInputDOMProps } from '@react-types/shared'
 import { IconEye, IconEyeClosed, IconLoader } from 'justd-icons'
 import {
@@ -11,6 +10,7 @@ import {
   type TextFieldProps as TextFieldPrimitiveProps
 } from 'react-aria-components'
 
+import { Loader } from './loader'
 import type { FieldProps } from './field'
 import { Description, FieldError, FieldGroup, fieldGroupPrefixStyles, Input, Label } from './field'
 import { ctr } from './primitive'


### PR DESCRIPTION
Awesome library!
Here I just unify the different approaches to import `ui` components inside `ui` folder, which caused problems where I had components in different location than suggested one `@/components`

Similar problem is with `theme-provider` which imports `next-themes` inside. Not everyone uses Next so it is problematic but I dont know how to fix it :) 